### PR TITLE
Update property.te to fix the issue for sdm710

### DIFF
--- a/generic/private/property.te
+++ b/generic/private/property.te
@@ -29,6 +29,7 @@
 # and vendor_exported_odm_prop
 vendor_restricted_prop(vendor_exported_system_prop);
 vendor_restricted_prop(vendor_exported_odm_prop);
+vendor_restricted_prop(vendor_persist_camera_prop);
 
 #mm-osal
 system_internal_prop(vendor_mm_osal_prop)


### PR DESCRIPTION
I get below error while building for RMX1851 which is having sdm710.
To fix this I have added a line of code.

```
[  0% 262/70101] //system/sepolicy:plat_policy_for_vendor.cil Building cil for plat_policy_for_vendor.cil [common] FAILED: /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/plat_policy_for_vendor.cil/android_common/plat_policy_for_vendor.cil /mnt/data/sos13/out/host/linux-x86/bin/checkpolicy -C -M -c 30 -o /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/plat_policy_for_vendor. cil/android_common/plat_policy_for_vendor.cil /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/plat_policy_for_vendor.conf/android_common/ plat_policy_for_vendor.conf && cat system/sepolicy/private/technical_debt.cil >>  /mnt/data/sos13/out/soong/.intermediates/system/sepolicy/plat_po licy_for_vendor.cil/android_common/plat_policy_for_vendor.cil && /mnt/data/sos13/out/host/linux-x86/bin/secilc -m -M true -G -c 30 /mnt/data/sos13 /out/soong/.intermediates/system/sepolicy/plat_policy_for_vendor.cil/android_common/plat_policy_for_vendor.cil -o /dev/null -f /dev/null # hash of
 input list: 7aff99e3a2dda226e35733afb96f47c506019c4e82a3404360f2d5bbee0734f6
device/qcom/sepolicy/generic/private/cameraserver.te:28:ERROR 'unknown type vendor_persist_camera_prop' at token ';' on line 77844: #line 28
allow cameraserver vendor_persist_camera_prop:file { getattr open read map }; checkpolicy:  error(s) encountered while parsing configuration 15:33:44 ninja failed with: exit status 1

#### failed to build some targets (01:21 (mm:ss)) ####
```

Review this.